### PR TITLE
Change conda installation channel

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -2,7 +2,7 @@ name: QSview
 
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 
 dependencies:
 


### PR DESCRIPTION
Due to licensing concerns switch from: https://github.com/BCDA-APS/QSview/blob/c7556b6e18c5431294e070c6f45dc59e7e8c7365/env.yml#L5

to the `nodefaults` channel.

Note this advice: https://stackoverflow.com/questions/67695893/
