### PR TITLE
25 add history sort order preference

### DIFF
--- a/src/QSview/mainwindow.py
+++ b/src/QSview/mainwindow.py
@@ -6,6 +6,8 @@ Defines MainWindow class.
     ~MainWindow
 """
 
+import csv
+
 from PyQt5 import QtWidgets
 
 from . import APP_TITLE, utils
@@ -52,6 +54,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actionClear.triggered.connect(self.doClear)
         self.actionAbout.triggered.connect(self.doAboutDialog)
         self.actionExit.triggered.connect(self.doClose)
+        self.actionSaveHistory.triggered.connect(self.doSaveHistory)
 
         # History sorting order
         self.actionSortNewestFirst.triggered.connect(self.doHistorySortToggle)
@@ -98,6 +101,10 @@ class MainWindow(QtWidgets.QMainWindow):
         # Store widget reference
         setattr(self, widget_name, widget)
 
+    # ========================================
+    # Status Bar Messages
+    # ========================================
+
     @property
     def message(self):
         """Returns the current message in the mainwindow status bar.
@@ -111,6 +118,10 @@ class MainWindow(QtWidgets.QMainWindow):
         """Write new message to the main window status bar and terminal output."""
         # print(text)
         self.statusbar.showMessage(str(text), msecs=timeout)
+
+    # ========================================
+    # Menu Control
+    # ========================================
 
     def doAboutDialog(self, *args, **kw):
         """
@@ -182,6 +193,92 @@ class MainWindow(QtWidgets.QMainWindow):
         if hasattr(self, "history_widget"):
             history_data = self.model.getHistory() if self.model else []
             self.history_widget._on_history_changed(history_data)
+
+    # ========================================
+    # Save History
+    # ========================================
+
+    def doSaveHistory(self):
+        """Save history to file"""
+        history_data = self.model.getHistory()
+        history_data = self.history_widget._apply_sort_setting(history_data)
+        if not history_data:
+            self.setMessage("No history to save")
+            return
+        rows = []
+        for history_item in history_data:
+            row_data = self.extract_row_data(history_item)
+            rows.append(row_data)
+        sorting = "newest" if settings.getHistorySortNewestFirst() else "oldest"
+        self.writeHistoryFile(rows, sorting)
+
+    def writeHistoryFile(self, rows, sorting):
+        """Write CSV file"""
+        filename, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Save History",
+            "",  # start directory (empty = default)
+            "CSV Files (*.csv);;All Files (*)",
+        )
+        if not filename:
+            return
+        try:
+            with open(filename, "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(
+                    ["Status", "Name", "Detector", "Arguments", "Metadata", "User"]
+                )
+                for row in rows:
+                    writer.writerow(row)
+                writer.writerow([])
+                writer.writerow([f"Sorted {sorting} first."])
+                self.setMessage(f"History saved to {filename}")
+        except Exception as e:
+            self.setMessage(f"Error saving history: {e}")
+
+    def extract_row_data(self, history_item):
+        """Extract data for a single row from history item."""
+        result = history_item.get("result", {})
+
+        # Get bound arguments (converts positional args to kwargs with proper names)
+        if self.model:
+            args, kwargs = self.model.get_bound_item_arguments(history_item)
+        else:
+            args = history_item.get("args", [])
+            kwargs = history_item.get("kwargs", {}).copy()
+
+        # Combine args and kwargs for formatting
+        if args:
+            kwargs["args"] = args
+
+        arguments = self.extract_arguments(kwargs)
+
+        return [
+            result.get("exit_status", "Unknown"),  # Status
+            history_item.get("name", "Unknown"),  # Name
+            arguments.get("det", ""),  # Detector
+            arguments.get("args", ""),  # Arguments
+            arguments.get("md", ""),  # Metadata
+            history_item.get("user", "Unknown"),  # User
+        ]
+
+    def extract_arguments(self, kwargs):
+        """Extract det, args and md from kwargs; returns a dictionary"""
+        columns = {}
+        if not kwargs:
+            return {}
+        if "detectors" in kwargs:
+            columns["det"] = kwargs["detectors"]
+        other_kwargs = {k: v for k, v in kwargs.items() if k not in ["detectors", "md"]}
+        if other_kwargs:
+            columns["args"] = other_kwargs
+        if "md" in kwargs:
+            columns["md"] = kwargs["md"]
+        return columns
+
+    # ========================================
+    # Connection Control
+    # ========================================
 
     def initializeConnection(self):
         """Initialize connection using the most recent server or show open dialog"""

--- a/src/QSview/mainwindow.py
+++ b/src/QSview/mainwindow.py
@@ -53,6 +53,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actionAbout.triggered.connect(self.doAboutDialog)
         self.actionExit.triggered.connect(self.doClose)
 
+        # History sorting order
+        self.actionSortNewestFirst.triggered.connect(self.doHistorySortToggle)
+        self.actionSortNewestFirst.setChecked(settings.getHistorySortNewestFirst())
+
         # Create widgets with connection
         self._setup_widget(StatusWidget, "groupBox_status", "status_widget")
         self._setup_widget(QueueEditorWidget, "groupBox_queue", "queue_editor_widget")
@@ -105,7 +109,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def setMessage(self, text, timeout=0):
         """Write new message to the main window status bar and terminal output."""
-        print(text)
+        # print(text)
         self.statusbar.showMessage(str(text), msecs=timeout)
 
     def doAboutDialog(self, *args, **kw):
@@ -165,6 +169,19 @@ class MainWindow(QtWidgets.QMainWindow):
         self.model.disconnectFromServer()
         self.doClose()
         event.accept()  # let the window close
+
+    def doHistorySortToggle(self):
+        """Toggle history sort direction."""
+
+        # Toggle the settings
+        current = settings.getHistorySortNewestFirst()
+        settings.setHistorySortNewestFirst(not current)
+        self.actionSortNewestFirst.setChecked(not current)
+
+        # Refresh the history display widget if it exist
+        if hasattr(self, "history_widget"):
+            history_data = self.model.getHistory() if self.model else []
+            self.history_widget._on_history_changed(history_data)
 
     def initializeConnection(self):
         """Initialize connection using the most recent server or show open dialog"""

--- a/src/QSview/queueserver_model.py
+++ b/src/QSview/queueserver_model.py
@@ -517,7 +517,7 @@ class QueueServerModel(QtCore.QObject):
             if response.get("success", False):
                 # Store in cache
                 self._history = response.get("items", [])
-                print(f"Fetched {len(self._history)} history items")  # Add this
+                # self.messageChanged.emit(f"Fetched {len(self._history)} history items")
                 # Emit signal for UI updates
                 self.historyChanged.emit(self._history)
                 return self._history

--- a/src/QSview/resources/history.ui
+++ b/src/QSview/resources/history.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>872</width>
-    <height>202</height>
+    <width>659</width>
+    <height>351</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -126,6 +126,20 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveHistoryButton">
+       <property name="toolTip">
+        <string>Save history to CSV</string>
+       </property>
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>icons/save.png</normaloff>icons/save.png</iconset>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="clearHistoryButton">

--- a/src/QSview/resources/mainwindow.ui
+++ b/src/QSview/resources/mainwindow.ui
@@ -229,6 +229,7 @@ QGroupBox::title {
     <addaction name="actionOpen"/>
     <addaction name="actionOpenRecent"/>
     <addaction name="actionClear"/>
+    <addaction name="actionSaveHistory"/>
     <addaction name="separator"/>
     <addaction name="actionPreferences"/>
     <addaction name="separator"/>
@@ -312,6 +313,11 @@ QGroupBox::title {
    </property>
    <property name="text">
     <string>Sort newest history item first</string>
+   </property>
+  </action>
+  <action name="actionSaveHistory">
+   <property name="text">
+    <string>Save History to CSV</string>
    </property>
   </action>
  </widget>

--- a/src/QSview/resources/mainwindow.ui
+++ b/src/QSview/resources/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>875</width>
-    <height>754</height>
+    <height>726</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -245,8 +245,15 @@ QGroupBox::title {
     </property>
     <addaction name="actionAbout"/>
    </widget>
+   <widget class="QMenu" name="menuView">
+    <property name="title">
+     <string>View</string>
+    </property>
+    <addaction name="actionSortNewestFirst"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
+   <addaction name="menuView"/>
    <addaction name="menu"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
@@ -294,6 +301,17 @@ QGroupBox::title {
   <action name="actionClear">
    <property name="text">
     <string>Clear Recent Servers</string>
+   </property>
+  </action>
+  <action name="actionSortNewestFirst">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Sort newest history item first</string>
    </property>
   </action>
  </widget>

--- a/src/QSview/user_settings.py
+++ b/src/QSview/user_settings.py
@@ -288,6 +288,21 @@ class ApplicationQSettings(QtCore.QSettings):
             # No current server to keep, clear everything
             self.setKey("servers/recent_servers", "")
 
+    def getHistorySortNewestFirst(self):
+        """Get the saved history sorting preference (default: True for newest first)."""
+        value = self.getKey("history/sort_newest_first")
+        if value is None:
+            return True
+        # QSettings with IniFormat stores booleans as strings, so convert string to bool
+        if isinstance(value, str):
+            return value.lower() not in ("false", "0", "")
+        else:
+            return bool(value)
+
+    def setHistorySortNewestFirst(self, newest_first=True):
+        """Set the history sorting preference"""
+        self.setKey("history/sort_newest_first", newest_first)
+
 
 # create _the_ singleton object
 settings = ApplicationQSettings(__settings_orgName__, __package_name__)

--- a/src/QSview/widgets/history.py
+++ b/src/QSview/widgets/history.py
@@ -51,6 +51,7 @@ class HistoryWidget(QtWidgets.QWidget):
 
         # Connect UI signals
         self.clearHistoryButton.clicked.connect(self._on_clear_clicked)
+        self.saveHistoryButton.clicked.connect(self._on_save_clicked)
         self.copyHistoryButton.clicked.connect(self._on_copy_to_queue_clicked)
         self.viewCheckBox.stateChanged.connect(self._on_toggle_view)
 
@@ -163,6 +164,12 @@ class HistoryWidget(QtWidgets.QWidget):
             if self.model:
                 self.model.clearHistory()
             self.model.messageChanged.emit("Queue cleared")
+
+    def _on_save_clicked(self):
+        """Save history to CSV file"""
+        main_window = self.window()
+        if main_window:
+            main_window.doSaveHistory()
 
     def _resize_table(self):
         """Resize table columns based on current model view type."""

--- a/src/QSview/widgets/history.py
+++ b/src/QSview/widgets/history.py
@@ -59,6 +59,14 @@ class HistoryWidget(QtWidgets.QWidget):
             self._update_copy_button_state
         )
 
+    def _apply_sort_setting(self, history_data):
+        """Apply sort setting to history data."""
+        from ..user_settings import settings
+
+        if settings.getHistorySortNewestFirst():
+            return history_data[::-1]  # Reverse to show newest first
+        return history_data
+
     def _on_history_changed(self, history_data):
         """Handle history changed signal"""
 
@@ -69,6 +77,7 @@ class HistoryWidget(QtWidgets.QWidget):
         h = hsb.value()
 
         # Update both models
+        history_data = self._apply_sort_setting(history_data)
         self.current_model.update_data(history_data)
 
         # Schedule resize, delegate and restore scroll position
@@ -96,11 +105,13 @@ class HistoryWidget(QtWidgets.QWidget):
             # Switch to dynamic
             self.current_model = self.dynamic_model
             self.viewCheckBox.setText("Detailed View")
+            history_data = self._apply_sort_setting(history_data)
             self.dynamic_model.update_data(history_data)
         else:
             # Switch to static
             self.current_model = self.static_model
             self.viewCheckBox.setText("Summary View")
+            history_data = self._apply_sort_setting(history_data)
             self.static_model.update_data(history_data)
 
         # Update the table view
@@ -125,6 +136,7 @@ class HistoryWidget(QtWidgets.QWidget):
 
         # Get the history data for selected rows
         history_data = self.model.getHistory()
+        history_data = self._apply_sort_setting(history_data)
         selected_items = []
 
         for row in selected_rows:
@@ -205,6 +217,7 @@ class HistoryWidget(QtWidgets.QWidget):
                     # Re-render to get correct column headers
                     history_data = self.model.getHistory() if self.model else []
                     if history_data:
+                        history_data = self._apply_sort_setting(history_data)
                         self.dynamic_model.update_data(history_data)
                         QTimer.singleShot(0, self._resize_table)
                         self._plans_loaded_rendered = True


### PR DESCRIPTION

- close #25: Add user-configurable history sort order preference
    - Default behavior: newest items appear first (`True`)
    - Add menu action 'Sort newest history item first' in View menu
    - Implement settings methods to save/load sort preference
    
- close #34: commented out the `print(txt)` from `setMessage(txt)` (method to set status in the main window status bar)

- close #20: 
    - Add 'Save History' menu action in File menu
    - Add save button in history widget toolbar
    - Implement `doSaveHistory()` method in MainWindow to save history as CSV
    - Extract data with separate columns for Status, Name, Detector, Arguments, Metadata, User
    - Apply current sort setting to saved data (matches display)
    - Include sort order indication at end of CSV file